### PR TITLE
fix error timzone during launch application

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -50,4 +50,10 @@ class AppKernel extends Kernel
     {
         $loader->load($this->getRootDir().'/config/config_'.$this->getEnvironment().'.yml');
     }
+
+    public function __construct($environment, $debug)
+    {
+        date_default_timezone_set('Europe/Paris');
+        parent::__construct($environment, $debug);
+    }
 }


### PR DESCRIPTION
règle le soucis de timezone au lancement de l'application si le phpinfo pas à jour.